### PR TITLE
Make the github pages deployment work like an actual spa

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpx semantic-release
 
+      - name: Prepare for github pages deployment
+        run: cp dist/index.html dist/404.html
+
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:


### PR DESCRIPTION
before this when accessing any other page than / the page loaded was the default github 404 error. Now the ci should change the 404 page to the root page automatically